### PR TITLE
Fix git ll to work with repos with few commits

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -20,7 +20,7 @@
 	fixup = commit --amend -C HEAD
 	lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 	lga = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all
-	ll = !git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all --since=\"$(git show -s --pretty=format:'%cd' master~3)\"
+	ll = !git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all --max-count=4
 	pop = stash pop
 	rev = diff --staged -M
 	review = diff --staged


### PR DESCRIPTION
Previously, `git ll` would try to calculate the date of the 4th previous
commit.  We can use git log's `--max-count` instead of `--since` flag to
limit this, without running into problems if we only have a few commits.

Fixes #1 
