### PR TITLE
Add appropriate warning about git ll

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -20,7 +20,7 @@
 	fixup = commit --amend -C HEAD
 	lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 	lga = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all
-	ll = !git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all --since=\"$(git show -s --pretty=format:'%cd' master~3)\"
+	ll = !echo "WARNING---HORRIBLY UNMAINTAINED" && git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all --since=\"$(git show -s --pretty=format:'%cd' master~3)\"
 	pop = stash pop
 	rev = diff --staged -M
 	review = diff --staged


### PR DESCRIPTION
Useless and less clearly untested. Warning still usefully POSIX compliant.
